### PR TITLE
RetireJS added to the repository. Included output SBOM as a markdown.

### DIFF
--- a/retirejsoutputfile.md
+++ b/retirejsoutputfile.md
@@ -1,0 +1,272 @@
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:4e142337-3e2b-499c-bc12-b2d965f977bb" version="1">
+  <metadata>
+    <timestamp>2023-03-18T01:06:22.564Z</timestamp>
+    <tools>
+        <tool>
+            <vendor>RetireJS</vendor>
+            <name>retire.js</name>
+            <version>3.2.3</version>
+        </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library">
+      <name>moment.js</name>
+      <version>2.24.0</version>
+      <purl>pkg:npm/moment.js@2.24.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.10.2</version>
+      <purl>pkg:npm/jquery@1.10.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.11.0</version>
+      <purl>pkg:npm/jquery@1.11.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.11.3</version>
+      <purl>pkg:npm/jquery@1.11.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.11.2</version>
+      <purl>pkg:npm/jquery@1.11.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.11.1</version>
+      <purl>pkg:npm/jquery@1.11.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.12.0</version>
+      <purl>pkg:npm/jquery@1.12.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.12.1</version>
+      <purl>pkg:npm/jquery@1.12.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.12.3</version>
+      <purl>pkg:npm/jquery@1.12.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.12.2</version>
+      <purl>pkg:npm/jquery@1.12.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.10.1</version>
+      <purl>pkg:npm/jquery@1.10.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.8.1</version>
+      <purl>pkg:npm/jquery@1.8.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.12.4</version>
+      <purl>pkg:npm/jquery@1.12.4</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.8.2</version>
+      <purl>pkg:npm/jquery@1.8.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.8.0</version>
+      <purl>pkg:npm/jquery@1.8.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.8.3</version>
+      <purl>pkg:npm/jquery@1.8.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.0.0</version>
+      <purl>pkg:npm/jquery@2.0.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.9.0</version>
+      <purl>pkg:npm/jquery@1.9.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.0.1</version>
+      <purl>pkg:npm/jquery@2.0.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.0.2</version>
+      <purl>pkg:npm/jquery@2.0.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.1.1</version>
+      <purl>pkg:npm/jquery@2.1.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.1.2</version>
+      <purl>pkg:npm/jquery@2.1.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.1.0</version>
+      <purl>pkg:npm/jquery@2.1.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.10.0</version>
+      <purl>pkg:npm/jquery@1.10.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.0.3</version>
+      <purl>pkg:npm/jquery@2.0.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.1.4</version>
+      <purl>pkg:npm/jquery@2.1.4</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.2.0</version>
+      <purl>pkg:npm/jquery@2.2.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.2.2</version>
+      <purl>pkg:npm/jquery@2.2.2</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.2.3</version>
+      <purl>pkg:npm/jquery@2.2.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.9.1</version>
+      <purl>pkg:npm/jquery@1.9.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.2.4</version>
+      <purl>pkg:npm/jquery@2.2.4</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.1.0</version>
+      <purl>pkg:npm/jquery@3.1.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.2.0</version>
+      <purl>pkg:npm/jquery@3.2.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.2.1</version>
+      <purl>pkg:npm/jquery@3.2.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.1.1</version>
+      <purl>pkg:npm/jquery@3.1.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.3.0</version>
+      <purl>pkg:npm/jquery@3.3.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.2.1</version>
+      <purl>pkg:npm/jquery@2.2.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.0.0</version>
+      <purl>pkg:npm/jquery@3.0.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.4.0</version>
+      <purl>pkg:npm/jquery@3.4.0</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.4.1</version>
+      <purl>pkg:npm/jquery@3.4.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>3.3.1</version>
+      <purl>pkg:npm/jquery@3.3.1</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>2.1.3</version>
+      <purl>pkg:npm/jquery@2.1.3</purl>
+      <modified>false</modified>
+    </component>
+    <component type="library">
+      <name>jquery</name>
+      <version>1.7.2</version>
+      <purl>pkg:npm/jquery@1.7.2</purl>
+      <modified>false</modified>
+    </component>
+  </components>
+</bom>


### PR DESCRIPTION
[Link](https://github.com/retirejs/retire.js/) to package documentation.

Considering issues with security vulnerabilities in the new and older codebase, this tool helps identify those issues. 
Updated package.json and can use "npx retire" or "npm run retire" to generate output.
Evidence stored as markdown file in retirejsoutputfile.md. 